### PR TITLE
Point the varnish deb repos to the correct urls

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -19,10 +19,10 @@ case node['platform_family']
 when 'debian'
   include_recipe 'apt'
   apt_repository 'varnish-cache' do
-    uri "http://repo.varnish-cache.org/#{node['platform']}"
+    uri "https://packagecloud.io/varnishcache/varnish#{node['varnish']['version']}/#{node['platform']}/"
     distribution node['lsb']['codename']
-    components ["varnish-#{node['varnish']['version']}"]
-    key "http://repo.varnish-cache.org/#{node['platform']}/GPG-key.txt"
+    components ["main"]
+    key "https://packagecloud.io/varnishcache/varnish#{node['varnish']['version']}/gpgkey"
     deb_src true
     notifies 'nothing', 'execute[apt-get update]', 'immediately'
   end


### PR DESCRIPTION
https://jira.takealot.com/jira/browse/DEVOPS-992

This is blocking both ML from deploying new solr-lb configs, as well as
Ecom from deploying api-lb configs.

Amend our local fork for the varnish cookbook to point to the correct
urls